### PR TITLE
Allow newer version of numpy in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-.pyc
+*.pyc
+*.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 
 requirements = (
-    'numpy>=1.9.0,<1.21',  # the real requirements is probably higher than that
+    'numpy>=1.20.0,<1.23',
     'pyproj',
     'cython',
     'triangle',


### PR DESCRIPTION
The current version of `Oslandia/py3dtiles` allows version range `>=1.20.0,<1.23` for numpy, see https://gitlab.com/Oslandia/py3dtiles/-/blob/master/setup.py#L9

Using the same range makes our py3dtiles compatible with viz-staging and viz-raster.